### PR TITLE
feat: Adds cloudinit and vars needed to use it. -AM

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,24 @@
 # required variables
+variable "os_type" {
+  type = string
+}
+
+variable "admin_ssh_publickey" {
+  type = string
+}
+
+variable "domain_name" {
+  type = string
+}
+
+variable "local_admin_secret" {
+  type = string
+}
+
+variable "local_admin_username" {
+  type = string
+}
+
 variable "nutanix_cluster_name" {
   type        = string
   description = "The name of the nutanix cluster"


### PR DESCRIPTION
As per issue [1](User creation and ssh user creation should use sysprep and cloudinit) this utlized the cloudinit feature of the nutanix providor to set the hostname, create local admin, set their password, and associate a public ssh key with them.

